### PR TITLE
For system sqlite3, make chicken-sqlite3 a thin wrapper around sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,10 @@
 *.import.scm
 *.types
 *~
+*.build.sh
+*.install.sh
+*.o
+*.link
 
 version-check
+chicken-sqlite3

--- a/build-chicken-sqlite3
+++ b/build-chicken-sqlite3
@@ -6,7 +6,7 @@ sqlite3_options="-C -DSQLITE_ENABLE_FTS3 -C -DSQLITE_ENABLE_FTS3_PARENTHESIS -C 
 
 if ./use-system-sqlite3; then
     echo "SQlite3 version `./version-check` found"
-    "$CHICKEN_CSC" -C "$CFLAGS -DUSE_SYSTEM_SQLITE=1" -L "$LDFLAGS -lsqlite3" -Isqlite3 "$@"
+    cp chicken-sqlite3.sh chicken-sqlite3
 else
     echo "Using built-in SQLite3"
     "$CHICKEN_CSC" -C "$CFLAGS" -L "$LDFLAGS" \

--- a/chicken-sqlite3.sh
+++ b/chicken-sqlite3.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+sqlite3 "$@"

--- a/sql-de-lite.egg
+++ b/sql-de-lite.egg
@@ -6,6 +6,7 @@
  (license "BSD")
  (dependencies foreigners object-evict srfi-18 srfi-69) ;; And bind if you want to update sqlite3-api
  (test-dependencies test)
+ (version "0.7.2")
  (components (extension sql-de-lite
                         (custom-build "build-sql-de-lite")
                         (types-file)


### PR DESCRIPTION
On macosx the "sqlite3_load_extension" API is removed because macos is silly.
The built-in shell.c assumes the API is available, so compilation against
the system sqlite3 fails.

Generally, compiling a random version of shell.c against another sqlite3
library is not guaranteed to work.

This patch installs "chicken-sqlite3" unconditionally -- if using the
system sqlite3, it's just a wrapper script that calls sqlite3.

chicken-sqlite3 is provided as a debugging convenience for the user,
so if this isn't exactly the right shell or if calling the shell fails,
it's not the end of the world.