### PR TITLE
Workaround recent breaking change in csc

### DIFF
--- a/build-chicken-sqlite3
+++ b/build-chicken-sqlite3
@@ -4,7 +4,7 @@ set -e
 
 sqlite3_options="-C -DSQLITE_ENABLE_FTS3 -C -DSQLITE_ENABLE_FTS3_PARENTHESIS -C -DSQLITE_THREADSAFE=0"
 
-if ./use-system-sqlite3; then
+if /bin/sh ./use-system-sqlite3; then
     echo "SQlite3 version `./version-check` found"
     cp chicken-sqlite3.sh chicken-sqlite3
 else

--- a/build-sql-de-lite
+++ b/build-sql-de-lite
@@ -2,6 +2,11 @@
 
 set -e
 
+# terrible workaround for passing the correct options to the manual
+# compile of sqlite3/sqlite3.c:
+static=`$CHICKEN_CSI -s fixup.scm -s "$@"`
+opts=`$CHICKEN_CSI -s fixup.scm -o sql-de-lite.scm "$@"`
+
 # If threadsafe=1, pthreads is required, so let's not.
 sqlite3_options="-C -DSQLITE_ENABLE_FTS3 -C -DSQLITE_ENABLE_FTS3_PARENTHESIS -C -DSQLITE_THREADSAFE=0"
 
@@ -10,6 +15,11 @@ if /bin/sh ./use-system-sqlite3; then
     "$CHICKEN_CSC" -C "$CFLAGS" -L "$LDFLAGS -lsqlite3" "$@"
 else
     echo "Using built-in SQLite3"
+    if ! test -f sqlite3/sqlite3$static.o; then
+        "$CHICKEN_CSC" $opts -C "$CFLAGS" -L "$LDFLAGS" \
+    		   -c -Isqlite3 sqlite3/sqlite3.c $sqlite3_options \
+                                      -o sqlite3/sqlite3$static.o
+    fi
     "$CHICKEN_CSC" -C "$CFLAGS" -L "$LDFLAGS" "$@" \
-		   -Isqlite3 sqlite3/sqlite3.c $sqlite3_options
+		   -Isqlite3 sqlite3/sqlite3$static.o $sqlite3_options
 fi

--- a/build-sql-de-lite.bat
+++ b/build-sql-de-lite.bat
@@ -2,5 +2,11 @@
 
 SET SQLITE3_OPTIONS=-C -DSQLITE_ENABLE_FTS3 -C -DSQLITE_ENABLE_FTS3_PARENTHESIS -C -DSQLITE_THREADSAFE=0
 
+%CHICKEN_CSI% -s fixup.scm -s %* > static.tmp
+SET /P STATIC=<static.tmp
+%CHICKEN_CSI% -s fixup.scm -o %* > opts.tmp
+SET /P OPTS=<opts.tmp
+
 REM For now we just always build with the shipped sqlite3 version.
-%CHICKEN_CSC% -C %CFLAGS% -L %LDFLAGS% %* -Isqlite3 sqlite3/sqlite3.c %SQLITE3_OPTIONS% -C -DSQLITE_THREADSAFE=0
+IF NOT EXISTS sqlite3\sqlite3%STATIC%.o %CHICKEN_CSC% %OPTS% -C %CFLAGS% -L %LDFLAGS% -c -Isqlite3 sqlite3/sqlite3.c %SQLITE3_OPTIONS% -o sqlite3/sqlite3%STATIC%.o
+%CHICKEN_CSC% -C %CFLAGS% -L %LDFLAGS% %* -Isqlite3 sqlite3/sqlite3.c %SQLITE3_OPTIONS% -C -DSQLITE_THREADSAFE=0 sqlite3/sqlite3%STATIC%.o

--- a/fixup.scm
+++ b/fixup.scm
@@ -1,0 +1,21 @@
+;;; fixup command-line options for secondary C file
+
+(import (chicken process-context))
+
+(define args (command-line-arguments))
+
+(cond ((string=? "-s" (car args))
+       (when (member "-static" (cdr args))
+         (print "static")))
+      ((string=? "-o" (car args))
+       (let ((fname (cadr args)))
+         (let loop ((args (cdr args)))
+           (cond ((null? args))
+                 ((string=? "-o" (car args))
+                  (loop (cddr args)))
+                 ((string=? fname (car args))
+                  (loop (cdr args)))
+                 (else 
+                   (write-char #\space)
+                   (display (car args))
+                   (loop (cdr args))))))))


### PR DESCRIPTION
Recently (version 5.2.0), csc does disallow multiple source files when given the "-c" command-line option. Several eggs use custom build scripts to pass addition files holding C code to the csc-invocation for an extension and all of these break now.

The proper method would be to use a "c-object" component in the extension, but this feature was not available in 5.0.0, so we are in a dilemma.

These patches filter the command-line options and compile the C file "by hand", adding only the object file to the csc-invocation.

This patch has been tested on OpenBSD with CHICKENs 5.0.0 and 5.2.0. It has NOT been tested on WIndows.