### PR TITLE
Implement savepoint functionality

### DIFF
--- a/sql-de-lite.egg
+++ b/sql-de-lite.egg
@@ -7,7 +7,7 @@
  (author "Jim Ursetto")
  (category db)
  (license "BSD")
- (dependencies foreigners object-evict srfi-18 srfi-69) ;; And bind if you want to update sqlite3-api
+ (dependencies foreigners object-evict srfi-1 srfi-18 srfi-69) ;; And bind if you want to update sqlite3-api
  (test-dependencies test)
  (version "0.8.1")
  (components (extension sql-de-lite

--- a/sql-de-lite.scm
+++ b/sql-de-lite.scm
@@ -608,8 +608,8 @@ int busy_notification_handler(void *ctx, int times) {
       (let ((rv (sqlite3_finalize
                  (statement-ptr stmt)))) ; don't use nonnull-statement-ptr, because that checks cached status
         (dprint 'rv rv)
-        (set-statement-ptr! stmt #f)
         (remove-active-statement! stmt)
+        (set-statement-ptr! stmt #f)
         (cond ((= rv status/abort)
                (database-error
                 (statement-db stmt) rv 'finalize))

--- a/sql-de-lite.scm
+++ b/sql-de-lite.scm
@@ -77,7 +77,7 @@ int busy_notification_handler(void *ctx, int times) {
   (chicken-4
    (import (except chicken reset))
    (import (only extras fprintf sprintf))
-   (require-library lolevel srfi-18)
+   (require-library lolevel srfi-1 srfi-18)
    (import (only lolevel
                  object->pointer object-release object-evict pointer=?))
    (import (only data-structures alist-ref))


### PR DESCRIPTION
These savepoint / nested transaction patches are from Andy Bennett. I untabified them
to match style, and updated the version number so they apply cleanly.

- Remove statement from hash-table then set pointer during finalize-transient
- Add nested transaction support to active-statements list
- SAVEPOINT Transactions
- Allow multiple values to be returned by with-transaction
- untabify savepoint patches
