### PR TITLE
Allow loading extensions from Scheme code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.so
+*.dylib
 *.a
 *.import.scm
 *.types

--- a/sql-de-lite.egg
+++ b/sql-de-lite.egg
@@ -8,7 +8,7 @@
  (category db)
  (license "BSD")
  (dependencies foreigners object-evict srfi-1 srfi-18 srfi-69) ;; And bind if you want to update sqlite3-api
- (test-dependencies test)
+ (test-dependencies test compile-file)
  (version "0.9.0")
  (components (extension sql-de-lite
                         (types-file)

--- a/sqlite3-api.h
+++ b/sqlite3-api.h
@@ -109,3 +109,9 @@ int sqlite3_value_numeric_type(sqlite3_value*);
 
 void *sqlite3_user_data(sqlite3_context*);
 void *sqlite3_aggregate_context(sqlite3_context*, int nBytes);
+int sqlite3_load_extension(
+  sqlite3 *db,          /* Load the extension into this database connection */
+  const char *zFile,    /* Name of the shared library containing extension */
+  const char *zProc,    /* Entry point.  Derived from zFile if 0 */
+  char **pzErrMsg       /* Put error message here if not 0 */
+);

--- a/sqlite3-api.scm
+++ b/sqlite3-api.scm
@@ -472,6 +472,16 @@
         (c-pointer void)
         "sqlite3_aggregate_context"
         (c-pointer "sqlite3_context")
-        integer))))
+        integer)))
+
+  (begin
+    (define sqlite3_load_extension
+      (foreign-lambda
+        integer
+        "sqlite3_load_extension"
+        (c-pointer "sqlite3")
+        c-string
+        c-string
+        (c-pointer (c-pointer char))))))
 
 ;;; END OF FILE

--- a/tests/rot13.c
+++ b/tests/rot13.c
@@ -1,0 +1,115 @@
+/*
+** 2013-05-15
+**
+** The author disclaims copyright to this source code.  In place of
+** a legal notice, here is a blessing:
+**
+**    May you do good and not evil.
+**    May you find forgiveness for yourself and forgive others.
+**    May you share freely, never taking more than you give.
+**
+******************************************************************************
+**
+** This SQLite extension implements a rot13() function and a rot13
+** collating sequence.
+*/
+#include "sqlite3ext.h"
+SQLITE_EXTENSION_INIT1
+#include <assert.h>
+#include <string.h>
+
+/*
+** Perform rot13 encoding on a single ASCII character.
+*/
+static unsigned char rot13(unsigned char c){
+  if( c>='a' && c<='z' ){
+    c += 13;
+    if( c>'z' ) c -= 26;
+  }else if( c>='A' && c<='Z' ){
+    c += 13;
+    if( c>'Z' ) c -= 26;
+  }
+  return c;
+}
+
+/*
+** Implementation of the rot13() function.
+**
+** Rotate ASCII alphabetic characters by 13 character positions.  
+** Non-ASCII characters are unchanged.  rot13(rot13(X)) should always
+** equal X.
+*/
+static void rot13func(
+  sqlite3_context *context,
+  int argc,
+  sqlite3_value **argv
+){
+  const unsigned char *zIn;
+  int nIn;
+  unsigned char *zOut;
+  unsigned char *zToFree = 0;
+  int i;
+  unsigned char zTemp[100];
+  assert( argc==1 );
+  if( sqlite3_value_type(argv[0])==SQLITE_NULL ) return;
+  zIn = (const unsigned char*)sqlite3_value_text(argv[0]);
+  nIn = sqlite3_value_bytes(argv[0]);
+  if( nIn<sizeof(zTemp)-1 ){
+    zOut = zTemp;
+  }else{
+    zOut = zToFree = (unsigned char*)sqlite3_malloc64( nIn+1 );
+    if( zOut==0 ){
+      sqlite3_result_error_nomem(context);
+      return;
+    }
+  }
+  for(i=0; i<nIn; i++) zOut[i] = rot13(zIn[i]);
+  zOut[i] = 0;
+  sqlite3_result_text(context, (char*)zOut, i, SQLITE_TRANSIENT);
+  sqlite3_free(zToFree);
+}
+
+/*
+** Implement the rot13 collating sequence so that if
+**
+**      x=y COLLATE rot13
+**
+** Then 
+**
+**      rot13(x)=rot13(y) COLLATE binary
+*/
+static int rot13CollFunc(
+  void *notUsed,
+  int nKey1, const void *pKey1,
+  int nKey2, const void *pKey2
+){
+  const char *zA = (const char*)pKey1;
+  const char *zB = (const char*)pKey2;
+  int i, x;
+  for(i=0; i<nKey1 && i<nKey2; i++){
+    x = (int)rot13(zA[i]) - (int)rot13(zB[i]);
+    if( x!=0 ) return x;
+  }
+  return nKey1 - nKey2;
+}
+
+
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+int sqlite3_rot_init(
+  sqlite3 *db, 
+  char **pzErrMsg, 
+  const sqlite3_api_routines *pApi
+){
+  int rc = SQLITE_OK;
+  SQLITE_EXTENSION_INIT2(pApi);
+  (void)pzErrMsg;  /* Unused parameter */
+  rc = sqlite3_create_function(db, "rot13", 1,
+                   SQLITE_UTF8|SQLITE_INNOCUOUS|SQLITE_DETERMINISTIC,
+                   0, rot13func, 0, 0);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3_create_collation(db, "rot13", SQLITE_UTF8, 0, rot13CollFunc);
+  }
+  return rc;
+}

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -2,11 +2,12 @@
   (chicken-4
    (use test)
    (use sql-de-lite)
+   (use compile-file)
    (use files)                          ; create-temporary-file
    (use posix))                         ; delete-file
   (else
-   (import test sql-de-lite (chicken file) (chicken blob)
-           (chicken string) (chicken format))))
+   (import test sql-de-lite compile-file (chicken file) (chicken blob)
+           (chicken pathname) (chicken string) (chicken format))))
 
 ;; Concatenate string literals into a single literal at compile time.
 ;; (string-literal "a" "b" "c") -> "abc"
@@ -1170,6 +1171,39 @@
 ;;         (and (step s) (error "step should have failed due to lock"))))
 ;;     ;; Statement should successfully be finalized in let-prepare
 ;;     (reset *s1*)))    ;; reset should fail with finalized statement error
+
+(let* (
+       (test-directory (or (pathname-directory ##sys#current-source-filename) "."))
+       (source (make-pathname test-directory "rot13.c"))
+       (shared-object (make-pathname test-directory "rot13.so"))
+       (ext (pathname-strip-extension shared-object))
+       (include-directory (make-pathname
+			   `(,test-directory "..") "sqlite")))
+  (compile-file
+   source output-file: shared-object load: #f
+   options: (cons
+	     (string-append "-I" include-directory) (compile-file-options)))
+  (test-group "extensions"
+    (test
+     "Calling function defined by extension"
+     '("uryyb jbeyq")
+     (call-with-database
+      ":memory:"
+      (lambda (db)
+	(load-extension! db ext #f)
+	(query fetch-row (sql db "select rot13('hello world')")))))
+    (test-error
+     "Unknown extension filename raises exception"
+     (call-with-database
+      ":memory:"
+      (lambda (db)
+	(load-extension! db (string-append test-directory "bogusobject") #f))))
+    (test-error
+     "Unknown extension entrypoint raises exception"
+     (call-with-database
+      ":memory:"
+      (lambda (db)
+	(load-extension! db ext "bogus_function"))))))
 
 (include "stmt-repro.scm")
 (include "cache.scm")

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -2,12 +2,13 @@
   (chicken-4
    (use test)
    (use sql-de-lite)
-   (use compile-file)
+   (use utils)                          ; compile-file
    (use files)                          ; create-temporary-file
    (use posix))                         ; delete-file
   (else
    (import test sql-de-lite compile-file (chicken file) (chicken blob)
-           (chicken pathname) (chicken string) (chicken format))))
+           (chicken pathname) (chicken string) (chicken format)
+           (chicken platform))))
 
 ;; Concatenate string literals into a single literal at compile time.
 ;; (string-literal "a" "b" "c") -> "abc"
@@ -1175,10 +1176,15 @@
 (let* (
        (test-directory (or (pathname-directory ##sys#current-source-filename) "."))
        (source (make-pathname test-directory "rot13.c"))
-       (shared-object (make-pathname test-directory "rot13.so"))
+       (load-library-extension
+        (cond ((eq? (software-type) 'windows) ".dll")
+              ((eq? (software-version) 'macosx) ".dylib")
+              (else ".so")))
+       (shared-object (make-pathname test-directory
+                                     (string-append "rot13" load-library-extension)))
        (ext (pathname-strip-extension shared-object))
        (include-directory (make-pathname
-			   `(,test-directory "..") "sqlite")))
+			   `(,test-directory "..") "sqlite3")))
   (compile-file
    source output-file: shared-object load: #f
    options: (cons


### PR DESCRIPTION
This only enables the C API for loading extensions, not the
load_extension SQL function.
The function load-extension! is exposed to Scheme..
