### PR TITLE
Use bignums in tests in CHICKEN 5 when running on 32-bit platforms

### DIFF
--- a/tests/run.scm
+++ b/tests/run.scm
@@ -694,10 +694,10 @@
              (exec (sql db "select rowid, * from cache where rowid = ?;")
                    rowid))
        (test (conc "last-insert-rowid on int64 rowid (numbers ok) " rowid)
-             (cond-expand (64bit rowid) (else (exact->inexact rowid)))
+             (cond-expand ((or 64bit (not chicken-4)) rowid) (else (exact->inexact rowid)))
              (last-insert-rowid db))
        (test (conc "retrieve row containing int64 rowid (numbers ok) " rowid)
-             `(,(cond-expand (64bit rowid) (else (exact->inexact rowid))) "jimmy" "dunno")
+             `(,(cond-expand ((or 64bit (not chicken-4)) rowid) (else (exact->inexact rowid))) "jimmy" "dunno")
              (exec (sql db "select rowid, * from cache where rowid = ?;")
                    rowid))))))
 


### PR DESCRIPTION
This would cause failing tests in Salmonella due to expecting an inexact: http://salmonella-linux-x86.call-cc.org/master/clang/linux/x86/2023/10/29/salmonella-report/test/sql-de-lite.html

When merging, please remember tag a minor release as well.